### PR TITLE
Adding more tests

### DIFF
--- a/src/dialog_submission/main_test.py
+++ b/src/dialog_submission/main_test.py
@@ -50,7 +50,7 @@ def test__verify_signature(
     The headers for timestamp and signature are in the function get_example_headers.
     """
     BODY = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
-    
+
     monkeypatch.setenv("SLACK_SIGNING_SECRET", slack_signing_secret)
     request_mock.headers.get.side_effect = get_example_headers
     request_mock.get_data.return_value = BODY
@@ -58,3 +58,16 @@ def test__verify_signature(
     with app.test_request_context():
         res = main._verify_signature(flask.request)
     assert res == expected_outcome
+
+
+def test_request_unauthenticated(app, monkeypatch):
+    """Test that the Flask Response will be HTTP status 401,
+    and that  the response indicates it was because the signature 
+    could not be verified.
+    """
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "secret")
+    with app.test_request_context(method="POST"):
+        res = main.dialog_submission(flask.request)
+        response = flask.make_response(res)
+    assert response.status_code == 401
+    assert response.get_data(as_text=True) == "Request signature invalid."

--- a/src/dialog_submission/main_test.py
+++ b/src/dialog_submission/main_test.py
@@ -52,9 +52,9 @@ def test__verify_signature(
     BODY = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
     
     monkeypatch.setenv("SLACK_SIGNING_SECRET", slack_signing_secret)
+    request_mock.headers.get.side_effect = get_example_headers
+    request_mock.get_data.return_value = BODY
+    time_mock.return_value = timestamp
     with app.test_request_context():
-        request_mock.headers.get.side_effect = get_example_headers
-        request_mock.get_data.return_value = BODY
-        time_mock.return_value = timestamp
         res = main._verify_signature(flask.request)
-        assert res == expected_outcome
+    assert res == expected_outcome

--- a/src/slash_command/main_test.py
+++ b/src/slash_command/main_test.py
@@ -52,9 +52,9 @@ def test__verify_signature(
     BODY = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c"
     
     monkeypatch.setenv("SLACK_SIGNING_SECRET", slack_signing_secret)
+    request_mock.headers.get.side_effect = get_example_headers
+    request_mock.get_data.return_value = BODY
+    time_mock.return_value = timestamp
     with app.test_request_context():
-        request_mock.headers.get.side_effect = get_example_headers
-        request_mock.get_data.return_value = BODY
-        time_mock.return_value = timestamp
         res = main._verify_signature(flask.request)
-        assert res == expected_outcome
+    assert res == expected_outcome

--- a/src/slash_command/main_test.py
+++ b/src/slash_command/main_test.py
@@ -1,5 +1,7 @@
+import json
 import flask
 import pytest
+import responses
 from unittest import mock
 
 import main
@@ -71,3 +73,31 @@ def test_request_unauthenticated(app, monkeypatch):
         response = flask.make_response(res)
     assert response.status_code == 401
     assert response.get_data(as_text=True) == "Request signature invalid."
+
+
+@responses.activate
+def test_dialog_trigger_request_towards_slack_dialog_api(app, monkeypatch):
+    """Test that the dialog trigger sends a request to Slack containing:
+    1. The oauth token from environment variable SLACK_OAUTH_TOKEN is used
+    2. trigger_id from request object is in the json structure of the HTTP body
+    3. Request is sent to Slack API endpoint https://slack.com/api/dialog.open
+    4. Request is sent using content-type application/json.
+    """
+    OAUTH_TOKEN = "my_oauth_token"
+    SLACK_DIALOG_API = "https://slack.com/api/dialog.open"
+    TRIGGER_ID = "13345224609.738474920.8088930838d88f008e0"
+    
+    responses.add(responses.POST, SLACK_DIALOG_API, json={"ok": True}, status=200)
+
+    monkeypatch.setenv("SLACK_OAUTH_TOKEN", OAUTH_TOKEN)
+    with app.test_request_context(
+        method="POST",
+        data=f"token=gIkuvaNzQIHg97ATvDxqgjtO&trigger_id={TRIGGER_ID}",
+        content_type="application/x-www-form-urlencoded",
+    ) as request:
+        main.trigger_dialog(request.request)
+
+    assert responses.calls[0].request.headers["Authorization"] == f"Bearer {OAUTH_TOKEN}"
+    assert json.loads(responses.calls[0].request.body)["trigger_id"] == TRIGGER_ID
+    assert responses.calls[0].request.url == SLACK_DIALOG_API
+    assert responses.calls[0].request.headers["Content-Type"] == "application/json"


### PR DESCRIPTION
Added new tests:
* Test that unauthenticated requests get a 401 from the cloud functions.
* Tests for the request sent towards Slack API for dialog.open

Modified tests:
* Re-structuring of the verify_signature test
